### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/tti

--- a/build.jam
+++ b/build.jam
@@ -7,11 +7,11 @@ import project ;
 
 project /boost/tti
     : common-requirements
-        <source>/boost/config//boost_config
-        <source>/boost/function_types//boost_function_types
-        <source>/boost/mpl//boost_mpl
-        <source>/boost/preprocessor//boost_preprocessor
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/config//boost_config
+        <library>/boost/function_types//boost_function_types
+        <library>/boost/mpl//boost_mpl
+        <library>/boost/preprocessor//boost_preprocessor
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,24 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/tti
+    : common-requirements
+        <source>/boost/config//boost_config
+        <source>/boost/function_types//boost_function_types
+        <source>/boost/mpl//boost_mpl
+        <source>/boost/preprocessor//boost_preprocessor
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_tti ]
+    [ alias all : boost_tti test ]
+    ;
+
+call-if : boost-library tti
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/tti
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,20 +5,23 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/config//boost_config
+    /boost/function_types//boost_function_types
+    /boost/mpl//boost_mpl
+    /boost/preprocessor//boost_preprocessor
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/tti
     : common-requirements
-        <library>/boost/config//boost_config
-        <library>/boost/function_types//boost_function_types
-        <library>/boost/mpl//boost_mpl
-        <library>/boost/preprocessor//boost_preprocessor
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_tti ]
+    [ alias boost_tti : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_tti test ]
     ;
 
 call-if : boost-library tti
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -13,12 +13,11 @@ constant boost_dependencies :
     /boost/type_traits//boost_type_traits ;
 
 project /boost/tti
-    : common-requirements
-        <include>include
     ;
 
 explicit
-    [ alias boost_tti : : : : <library>$(boost_dependencies) ]
+    [ alias boost_tti : : :
+        : <include>include <library>$(boost_dependencies) ]
     [ alias all : boost_tti test ]
     ;
 

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -37,38 +37,38 @@ else
 
 doxygen tti_reference
   :
-    $(here)/../../../boost/tti/has_class.hpp
-    $(here)/../../../boost/tti/has_data.hpp
-    $(here)/../../../boost/tti/has_enum.hpp
-    $(here)/../../../boost/tti/has_function.hpp
-    $(here)/../../../boost/tti/has_function_template.hpp
-    $(here)/../../../boost/tti/has_member_data.hpp
-    $(here)/../../../boost/tti/has_member_function.hpp
-    $(here)/../../../boost/tti/has_member_function_template.hpp
-    $(here)/../../../boost/tti/has_static_member_data.hpp
-    $(here)/../../../boost/tti/has_static_member_function.hpp
-    $(here)/../../../boost/tti/has_static_member_function_template.hpp
-    $(here)/../../../boost/tti/has_template.hpp
-    $(here)/../../../boost/tti/has_type.hpp
-    $(here)/../../../boost/tti/has_union.hpp
-    $(here)/../../../boost/tti/member_type.hpp
-    $(here)/../../../boost/tti/gen/has_class_gen.hpp
-    $(here)/../../../boost/tti/gen/has_data_gen.hpp
-    $(here)/../../../boost/tti/gen/has_enum_gen.hpp
-    $(here)/../../../boost/tti/gen/has_function_gen.hpp
-    $(here)/../../../boost/tti/gen/has_function_template_gen.hpp
-    $(here)/../../../boost/tti/gen/has_member_data_gen.hpp
-    $(here)/../../../boost/tti/gen/has_member_function_gen.hpp
-    $(here)/../../../boost/tti/gen/has_member_function_template_gen.hpp
-    $(here)/../../../boost/tti/gen/has_static_member_data_gen.hpp
-    $(here)/../../../boost/tti/gen/has_static_member_function_gen.hpp
-    $(here)/../../../boost/tti/gen/has_static_member_function_template_gen.hpp
-    $(here)/../../../boost/tti/gen/has_template_gen.hpp
-    $(here)/../../../boost/tti/gen/has_type_gen.hpp
-    $(here)/../../../boost/tti/gen/has_union_gen.hpp
-    $(here)/../../../boost/tti/gen/member_type_gen.hpp
-    $(here)/../../../boost/tti/gen/namespace_gen.hpp
-  : 
+    $(here)/../include/boost/tti/has_class.hpp
+    $(here)/../include/boost/tti/has_data.hpp
+    $(here)/../include/boost/tti/has_enum.hpp
+    $(here)/../include/boost/tti/has_function.hpp
+    $(here)/../include/boost/tti/has_function_template.hpp
+    $(here)/../include/boost/tti/has_member_data.hpp
+    $(here)/../include/boost/tti/has_member_function.hpp
+    $(here)/../include/boost/tti/has_member_function_template.hpp
+    $(here)/../include/boost/tti/has_static_member_data.hpp
+    $(here)/../include/boost/tti/has_static_member_function.hpp
+    $(here)/../include/boost/tti/has_static_member_function_template.hpp
+    $(here)/../include/boost/tti/has_template.hpp
+    $(here)/../include/boost/tti/has_type.hpp
+    $(here)/../include/boost/tti/has_union.hpp
+    $(here)/../include/boost/tti/member_type.hpp
+    $(here)/../include/boost/tti/gen/has_class_gen.hpp
+    $(here)/../include/boost/tti/gen/has_data_gen.hpp
+    $(here)/../include/boost/tti/gen/has_enum_gen.hpp
+    $(here)/../include/boost/tti/gen/has_function_gen.hpp
+    $(here)/../include/boost/tti/gen/has_function_template_gen.hpp
+    $(here)/../include/boost/tti/gen/has_member_data_gen.hpp
+    $(here)/../include/boost/tti/gen/has_member_function_gen.hpp
+    $(here)/../include/boost/tti/gen/has_member_function_template_gen.hpp
+    $(here)/../include/boost/tti/gen/has_static_member_data_gen.hpp
+    $(here)/../include/boost/tti/gen/has_static_member_function_gen.hpp
+    $(here)/../include/boost/tti/gen/has_static_member_function_template_gen.hpp
+    $(here)/../include/boost/tti/gen/has_template_gen.hpp
+    $(here)/../include/boost/tti/gen/has_type_gen.hpp
+    $(here)/../include/boost/tti/gen/has_union_gen.hpp
+    $(here)/../include/boost/tti/gen/member_type_gen.hpp
+    $(here)/../include/boost/tti/gen/namespace_gen.hpp
+  :
     <doxygen:param>PROJECT_NAME="TTI"
     <doxygen:param>PROJECT_NUMBER=1
     <doxygen:param>SORT_MEMBER_DOCS=NO
@@ -94,7 +94,7 @@ boostbook standalone
   <xsl:param>chunk.section.depth=8  # How far down we chunk nested sections, basically all of them.
   <xsl:param>toc.section.depth=8  # How far down sections get TOCs.
   <xsl:param>toc.max.depth=4  # Max depth in each TOC.
-  
+
   # PDF Options:
   # TOC Generation: this is needed for FOP-0.9 and later:
   <xsl:param>fop1.extensions=0

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -24,8 +24,9 @@ project tti_tests : requirements <warnings>on
                                  <toolset>gcc-4.6.3:<cxxflags>-Wno-variadic-macros
                                  <toolset>gcc-4.7.0:<cxxflags>-Wno-variadic-macros
                                  <toolset>gcc-4.7.2:<cxxflags>-Wno-variadic-macros
+                                 <library>/boost/tti//boost_tti
                                  ;
-                                 
+
 obj function_template : test_function_template_works.cpp ;
 
 explicit function_template ;
@@ -160,13 +161,13 @@ alias ttifun
     ;
 
 #
-# Member function templates 
+# Member function templates
 #
 alias ttimftmp
     :
         [ run test_has_mem_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_mem_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_mem_fun_template_nov ]
         [ compile test_has_mem_fun_template_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_mem_fun_template_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -181,7 +182,7 @@ alias ttimftsig
     :
         [ run test_has_member_template.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_member_template.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_member_template_nov ]
         [ compile test_has_member_template_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_member_template_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -196,7 +197,7 @@ alias ttimftmpcv
     :
         [ run test_has_mem_fun_template_cv.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_mem_fun_template_cv.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_mem_fun_template_cv_nov ]
         [ compile test_has_mem_fun_template_cv_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_mem_fun_template_cv_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -211,7 +212,7 @@ alias ttimftsigcv
     :
         [ run test_has_member_template_cv.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_member_template_cv.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_member_template_cv_nov ]
         [ compile test_has_member_template_cv_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_member_template_cv_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -220,13 +221,13 @@ alias ttimftsigcv
     ;
 
 #
-# Static member function templates 
+# Static member function templates
 #
 alias ttismftmp
     :
         [ run test_has_static_mem_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_static_mem_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_static_mem_fun_template_nov ]
         [ compile test_has_static_mem_fun_template_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_static_mem_fun_template_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -240,7 +241,7 @@ alias ttismftsig
     :
         [ run test_has_static_member_template.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_static_member_template.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_static_member_template_nov ]
         [ compile test_has_static_member_template_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_static_member_template_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -254,7 +255,7 @@ alias ttifuntmp
     :
         [ run test_has_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ] ]
         [ run test_has_fun_template.cpp : : : [ check-target-builds function_template : : <build>no ]
-          <define>BOOST_PP_VARIADICS=0 : 
+          <define>BOOST_PP_VARIADICS=0 :
           test_has_fun_template_nov ]
         [ compile test_has_fun_template_compile.cpp : [ check-target-builds function_template : : <build>no ] ]
         [ compile-fail test_has_fun_template_fail.cpp : [ check-target-builds function_template : : <build>no ] ]
@@ -292,7 +293,7 @@ alias ttitmpcp
         [ compile-fail test_has_template_cp_fail3.cpp : <define>BOOST_PP_VARIADICS=0 ]
         [ compile-fail test_has_template_cp_fail4.cpp : <define>BOOST_PP_VARIADICS=0 ]
     ;
-    
+
 #
 # Type
 #
@@ -328,207 +329,207 @@ alias ttimemty
 #
 alias ttinovm : ttimfsig ttimfsigcv ttimd ttimfn ttimfncv ttismfsig ttismd ttismfn ttidata ttifun ttitmp ttitmpcp ttity ttimemty ttift ;
 
-alias ttitmpv : : 
+alias ttitmpv : :
         <toolset>gcc
         <toolset-gcc:version>3.4.2
     ;
-    
-alias ttitmpv : : 
+
+alias ttitmpv : :
         <toolset>gcc
         <toolset-gcc:version>3.4.5
     ;
-    
-alias ttitmpv : : 
+
+alias ttitmpv : :
         <toolset>gcc
         <toolset-gcc:version>4.1.2
     ;
-    
-alias ttitmpv : : 
+
+alias ttitmpv : :
         <toolset>gcc
         <toolset-gcc:version>4.2.1
     ;
-    
+
 #
 # Templates, variadic macro
 #
 alias ttitmpv
     :
-        [ run test_has_template.cpp : : : 
+        [ run test_has_template.cpp : : :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_v ]
-        [ compile test_has_template_compile.cpp : 
+        [ compile test_has_template_compile.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_compile_v ]
-        [ compile-fail test_has_template_fail.cpp : 
+        [ compile-fail test_has_template_fail.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_fail_v ]
-        [ compile-fail test_has_template_fail2.cpp : 
+        [ compile-fail test_has_template_fail2.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_fail2_v ]
-        [ compile-fail test_has_template_fail3.cpp : 
+        [ compile-fail test_has_template_fail3.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_fail3_v ]
-        [ compile-fail test_has_template_fail4.cpp : 
+        [ compile-fail test_has_template_fail4.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_fail4_v ]
     ;
 
-alias ttitmpcpv : : 
+alias ttitmpcpv : :
         <toolset>gcc
         <toolset-gcc:version>3.4.2
     ;
-    
-alias ttitmpcpv : : 
+
+alias ttitmpcpv : :
         <toolset>gcc
         <toolset-gcc:version>3.4.5
     ;
-    
-alias ttitmpcpv : : 
+
+alias ttitmpcpv : :
         <toolset>gcc
         <toolset-gcc:version>4.1.2
     ;
-    
-alias ttitmpcpv : : 
+
+alias ttitmpcpv : :
         <toolset>gcc
         <toolset-gcc:version>4.2.1
     ;
-    
+
 #
 # Templates, variadic macro, check params, non-variadic syntax
 #
 alias ttitmpcpv
     :
-        [ run test_has_template_cp.cpp : : : 
+        [ run test_has_template_cp.cpp : : :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_v ]
-        [ compile test_has_template_cp_compile.cpp : 
+        [ compile test_has_template_cp_compile.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_compile_v ]
-        [ compile-fail test_has_template_cp_fail.cpp : 
+        [ compile-fail test_has_template_cp_fail.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_fail_v ]
-        [ compile-fail test_has_template_cp_fail2.cpp : 
+        [ compile-fail test_has_template_cp_fail2.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_fail2_v ]
-        [ compile-fail test_has_template_cp_fail3.cpp : 
+        [ compile-fail test_has_template_cp_fail3.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_fail3_v ]
-        [ compile-fail test_has_template_cp_fail4.cpp : 
+        [ compile-fail test_has_template_cp_fail4.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
-          <define>BOOST_PP_VARIADICS=1 : 
+          <define>BOOST_PP_VARIADICS=1 :
           test_has_template_cp_fail4_v  ]
     ;
-    
-alias ttitmpcpvm : : 
+
+alias ttitmpcpvm : :
         <toolset>gcc
         <toolset-gcc:version>3.4.2
     ;
-    
-alias ttitmpcpvm : : 
+
+alias ttitmpcpvm : :
         <toolset>gcc
         <toolset-gcc:version>3.4.5
     ;
-    
-alias ttitmpcpvm : : 
+
+alias ttitmpcpvm : :
         <toolset>gcc
         <toolset-gcc:version>4.1.2
     ;
-    
-alias ttitmpcpvm : : 
+
+alias ttitmpcpvm : :
         <toolset>gcc
         <toolset-gcc:version>4.2.1
     ;
-    
+
 #
 # Templates, variadic macro, check params, variadic syntax
 #
 alias ttitmpcpvm
     :
-        [ run test_vm_has_template_cp.cpp : : : 
+        [ run test_vm_has_template_cp.cpp : : :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
-        [ compile test_vm_has_template_cp_compile.cpp : 
+        [ compile test_vm_has_template_cp_compile.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
-        [ compile-fail test_vm_has_template_cp_fail.cpp : 
+        [ compile-fail test_vm_has_template_cp_fail.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
-        [ compile-fail test_vm_has_template_cp_fail2.cpp : 
+        [ compile-fail test_vm_has_template_cp_fail2.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
-        [ compile-fail test_vm_has_template_cp_fail3.cpp : 
+        [ compile-fail test_vm_has_template_cp_fail3.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
-        [ compile-fail test_vm_has_template_cp_fail4.cpp : 
+        [ compile-fail test_vm_has_template_cp_fail4.cpp :
           <toolset>gcc:<cxxflags>-std=c++0x
           <toolset>gcc-4.3.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.0:<cxxflags>-U__STRICT_ANSI__
           <toolset>gcc-4.4.7:<cxxflags>-U__STRICT_ANSI__
           <define>BOOST_PP_VARIADICS=1 ]
     ;
-    
+
 #
 # Templates, non-variadic macro
 #


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.